### PR TITLE
Added support for Predicate and UnaryOperator interfaces

### DIFF
--- a/function-generator/src/test/java/client_code/IsEvenTest.java
+++ b/function-generator/src/test/java/client_code/IsEvenTest.java
@@ -9,21 +9,22 @@ import org.junit.After;
 import org.junit.Test; // Import JUnit Test annotation
 import static org.junit.Assert.*; // Import JUnit assert methods
 
-import java.util.function.Function;
+// import java.util.function.Function;
+import java.util.function.Predicate;
 
 public class IsEvenTest {
     public static void main(String[] args) {
         OpenAIFunctionGenerator functionGenerator = OpenAIFunctionGenerator.builder().withApiKey(ConfigLoader.getInstance().getApiKey()).build();
-        Function<Integer, Boolean> isEven = FunctionGenerator.builder(Integer.class,Boolean.class)
+        Predicate<Integer> isEven = FunctionGenerator.builder(Integer.class,Boolean.class)
             // .withDescription("Determines if a given integer is even.") // Add description
             .withStrategy(functionGenerator)
             .withTestClass(IsEvenTest.class)
-            .build();
+            .buildPredicate();
 
         // Test the generated function
         System.out.println("\nTesting Generated Function:");
-        System.out.println("2 is even? " + isEven.apply(2));
-        System.out.println("5 is even? " + isEven.apply(5));
+        System.out.println("2 is even? " + isEven.test(2));
+        System.out.println("5 is even? " + isEven.test(5));
     }
 
     // Dummy function for TDD; Not implemented yet

--- a/function-generator/src/test/java/client_code/sql_server/backend/UserRequestToSQL.java
+++ b/function-generator/src/test/java/client_code/sql_server/backend/UserRequestToSQL.java
@@ -7,15 +7,16 @@ import strategies.openai.OpenAIFunctionGenerator;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import client_code.config.ConfigLoader;
 
 public class UserRequestToSQL {
     // Generated function to handle user input for books
-    private final Function<String, String> bookRequestToSQLFunction;
+    private final UnaryOperator<String> bookRequestToSQLFunction;
 
     // Generated function to handle user input for users
-    private final Function<String, String> userRequestToSQLFunction;
+    private final UnaryOperator<String> userRequestToSQLFunction;
 
     public UserRequestToSQL() {
         // Define scenarios for converting user input to SQL queries for books
@@ -76,7 +77,7 @@ public class UserRequestToSQL {
             .withStrategy(functionGenerator)
             .withExecutionError(new IllegalArgumentException( "Only search queries are allowed"), "User should not be able to create, modify or update records")
             .withExecutionError(new IllegalArgumentException("The data requested is not in the allowed columns"), "User should only query for data in title, author, genre and year columns")
-            .build();
+            .buildUnaryOperator();
 
         // Build the userRequestToSQLFunction
         this.userRequestToSQLFunction = FunctionGenerator.builder(String.class, String.class)
@@ -85,7 +86,7 @@ public class UserRequestToSQL {
             .withStrategy(functionGenerator)
             .withExecutionError(new IllegalArgumentException("Only seach queries are allowed"), "User should not be able to create, modify or update records")
             .withExecutionError(new IllegalArgumentException("The data requested is not in the allowed columns"), "User should only query for data in name, email, company and age columns")
-            .build();
+            .buildUnaryOperator();
     }
 
     // Method to process a user request for books


### PR DESCRIPTION
Added API support for returning functions as Predicate<T> and UnaryOperator<T>. Also updated client code to highlight usage of these two new interfaces.

Closes #8.